### PR TITLE
Add video grid with embedded videos

### DIFF
--- a/index.html
+++ b/index.html
@@ -504,7 +504,20 @@
     </section>
 
     <section id="video" class="inner-tab-content">
-      <p class="coming-soon">Torna presto per nuovi contenuti.</p>
+      <div class="video-grid">
+        <div class="video-box">
+          <iframe src="https://www.youtube.com/embed/KKNCiRWd_j0" title="Video 1" allowfullscreen></iframe>
+        </div>
+        <div class="video-box">
+          <iframe src="https://www.youtube.com/embed/jt3Ul3rPXaE" title="Video 2" allowfullscreen></iframe>
+        </div>
+        <div class="video-box">
+          <iframe src="https://www.youtube.com/embed/qyH3NxFz3Aw" title="Video 3" allowfullscreen></iframe>
+        </div>
+        <div class="video-box">
+          <iframe src="https://www.youtube.com/embed/CRraHg4Ks_g" title="Video 4" allowfullscreen></iframe>
+        </div>
+      </div>
     </section>
 
     <section id="podcast" class="inner-tab-content">


### PR DESCRIPTION
## Summary
- replace 'Torna presto' notice in Video tab with a grid of four embedded YouTube videos

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_688c9b7cb6c08320b86f9a48a833684b