### PR TITLE
Fix video details not showing

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,6 +171,10 @@
       display: block;
     }
 
+    #video .agenda-detail {
+      display: block;
+    }
+
     .toggle {
       margin-left: auto;
       font-size: 1.5rem;


### PR DESCRIPTION
## Summary
- display the "Perché vederlo" text under each video by default

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_688ccd70ec148320a1b88ed23f6bfdb8