### PR TITLE
Add podcast section with play links

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,7 +178,7 @@
       color: var(--primary);
     }
 
-    .cart-link {
+    .cart-link, .play-link {
       color: var(--primary);
       text-decoration: none;
       margin-left: auto;
@@ -193,7 +193,7 @@
       border: 2px solid var(--primary);
     }
 
-    .book-cover {
+    .book-cover, .podcast-cover {
       width: 72px;
       height: auto;
       border-radius: 4px;
@@ -611,7 +611,57 @@ Narrativa avvincente: analogie chiare (es. speciazione digitale, AI come compagn
     </section>
 
     <section id="podcast" class="inner-tab-content">
-      <p class="coming-soon">Torna presto per nuovi contenuti.</p>
+      <p class="reading-intro">5 podcast consigliati</p>
+
+      <section class="agenda-item">
+        <img class="podcast-cover" src="https://via.placeholder.com/72x72.png?text=P1" alt="Lex Fridman Podcast">
+        <div class="agenda-content">
+          <h3>Sam Altman: OpenAI, GPT-4 e il futuro</h3>
+          <p><em>Lex Fridman Podcast</em></p>
+          <p class="agenda-detail"><strong>Sinossi:</strong> Conversazione approfondita con il CEO di OpenAI su progressi e sfide dell'AI.<br><strong>Perché ascoltarlo:</strong> uno sguardo interno sul futuro delle AI generative.</p>
+        </div>
+        <a class="play-link icon" href="https://www.youtube.com/watch?v=L_Guz73e6fw" target="_blank" aria-label="Ascolta"><i class="fas fa-play"></i></a>
+      </section>
+
+      <section class="agenda-item">
+        <img class="podcast-cover" src="https://via.placeholder.com/72x72.png?text=P2" alt="Hard Fork">
+        <div class="agenda-content">
+          <h3>The State of AI in 2024</h3>
+          <p><em>Hard Fork</em></p>
+          <p class="agenda-detail"><strong>Sinossi:</strong> Roose e Newton discutono dei più recenti sviluppi dell'intelligenza artificiale.<br><strong>Perché ascoltarlo:</strong> analisi brillante dal mondo del giornalismo tech.</p>
+        </div>
+        <a class="play-link icon" href="https://www.nytimes.com/2024/01/19/podcasts/hard-fork-ai-openai.html" target="_blank" aria-label="Ascolta"><i class="fas fa-play"></i></a>
+      </section>
+
+      <section class="agenda-item">
+        <img class="podcast-cover" src="https://via.placeholder.com/72x72.png?text=P3" alt="Eye on AI">
+        <div class="agenda-content">
+          <h3>Making Sense of Artificial General Intelligence</h3>
+          <p><em>Eye on AI</em></p>
+          <p class="agenda-detail"><strong>Sinossi:</strong> Craig S. Smith intervista esperti su potenzialità e rischi dell'AGI.<br><strong>Perché ascoltarlo:</strong> prospettiva globale e informata sulle evoluzioni dell'AI.</p>
+        </div>
+        <a class="play-link icon" href="https://www.eyeonai.com/episodes" target="_blank" aria-label="Ascolta"><i class="fas fa-play"></i></a>
+      </section>
+
+      <section class="agenda-item">
+        <img class="podcast-cover" src="https://via.placeholder.com/72x72.png?text=P4" alt="In Machines We Trust">
+        <div class="agenda-content">
+          <h3>The Hidden Human Labor Behind AI</h3>
+          <p><em>In Machines We Trust</em></p>
+          <p class="agenda-detail"><strong>Sinossi:</strong> Jennifer Strong esplora il lavoro umano necessario per addestrare i sistemi AI.<br><strong>Perché ascoltarlo:</strong> mette in luce gli aspetti etici e sociali dietro la tecnologia.</p>
+        </div>
+        <a class="play-link icon" href="https://www.technologyreview.com/2023/06/06/1074017/in-machines-we-trust" target="_blank" aria-label="Ascolta"><i class="fas fa-play"></i></a>
+      </section>
+
+      <section class="agenda-item">
+        <img class="podcast-cover" src="https://via.placeholder.com/72x72.png?text=P5" alt="The Gradient Podcast">
+        <div class="agenda-content">
+          <h3>Yann LeCun: A Path Toward Autonomous AI</h3>
+          <p><em>The Gradient Podcast</em></p>
+          <p class="agenda-detail"><strong>Sinossi:</strong> Il padre del deep learning discute una visione alternativa per l'AI.<br><strong>Perché ascoltarlo:</strong> offre uno sguardo tecnico e ottimistico sul futuro dell'AI.</p>
+        </div>
+        <a class="play-link icon" href="https://thegradientpub.substack.com/p/yann-lecun-a-path-toward-autonomous" target="_blank" aria-label="Ascolta"><i class="fas fa-play"></i></a>
+      </section>
     </section>
   </section>
 </main>


### PR DESCRIPTION
## Summary
- Style shared play-link and podcast-cover classes for consistent icon and artwork presentation
- Replace placeholder podcast tab with five playable podcast recommendations

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6895c5890d2c83208488bae8de919f16