### PR TITLE
Fix missing podcast synopsis

### DIFF
--- a/index.html
+++ b/index.html
@@ -167,7 +167,8 @@
       display: block;
     }
 
-    #libri .agenda-detail {
+    #libri .agenda-detail,
+    #podcast .agenda-detail {
       display: block;
     }
 


### PR DESCRIPTION
## Summary
- ensure podcast section always shows synopsis and reason to listen

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6895cd5e2b008320be515f8fcf64e8fe